### PR TITLE
feat(profiles): add multi-term fuzzy filtering on name and command

### DIFF
--- a/Flow.Launcher.Plugin.easyssh/Main.cs
+++ b/Flow.Launcher.Plugin.easyssh/Main.cs
@@ -187,16 +187,33 @@ namespace Flow.Launcher.Plugin.EasySsh
                 case CommandProfiles:
                     {
                         var list = new List<Result>
-                    {
-                        new Result
                         {
-                            Title = GetTranslation("plugin_easyssh_title_commandprofiles"),
-                            SubTitle = GetTranslation("plugin_easyssh_subtitle_commandprofiles"),
-                            IcoPath = AppIconPath
-                        }
-                    };
+                            new Result
+                            {
+                                Title = GetTranslation("plugin_easyssh_title_commandprofiles"),
+                                SubTitle = GetTranslation("plugin_easyssh_subtitle_commandprofiles"),
+                                IcoPath = AppIconPath
+                            }
+                        };
 
-                        foreach (var kv in _profileManager.UserData.Entries.OrderBy(k => k.Key, StringComparer.OrdinalIgnoreCase))
+                        var searchTerms = parts.Skip(1)
+                            .Select(t => t.Trim())
+                            .Where(t => t.Length > 0)
+                            .ToArray();
+
+                        var entries = _profileManager.UserData.Entries;
+
+                        var filtered = searchTerms.Length == 0
+                            ? entries.OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase)
+                            : entries
+                                .Where(kv => searchTerms.All(term =>
+                                    kv.Key.Contains(term, StringComparison.OrdinalIgnoreCase)
+                                    || kv.Value.Contains(term, StringComparison.OrdinalIgnoreCase)))
+                                .OrderBy(kv => searchTerms.All(term =>
+                                    kv.Key.Contains(term, StringComparison.OrdinalIgnoreCase)) ? 0 : 1)
+                                .ThenBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase);
+
+                        foreach (var kv in filtered)
                         {
                             var key = kv.Key; var val = kv.Value;
                             list.Add(new Result

--- a/Flow.Launcher.Plugin.easyssh/plugin.json
+++ b/Flow.Launcher.Plugin.easyssh/plugin.json
@@ -4,7 +4,7 @@
     "Name": "EasySSH",
     "Description": "ssh with Flow-Launcher",
     "Author": "Melv1no",
-    "Version": "1.1.2.0",
+    "Version": "1.2.0.0",
     "Language": "csharp",
     "Website": "https://github.com/Melv1no/Flow.Launcher.Plugin.easyssh",
     "IcoPath": "Images\\app.png",


### PR DESCRIPTION
### What

The `ssh profiles` command now supports dynamic filtering with multi-term search.

**Syntax:** `ssh profiles <term1> <term2> ...`

### How it works

- Each search term is matched independently (substring, case-insensitive)
- A profile matches only if **all** terms are found across its name or SSH command
- Results are sorted with **name matches first**, then command-only matches
- Within each group, profiles are sorted alphabetically
- Empty search still returns all profiles sorted by name

### Example

With profiles `site_prod` (cmd: `ssh user@site.com`) and `site_staging` (cmd: `ssh user@preprod.site.com`):

| Query | Result |
|---|---|
| `ssh profiles prod` | `site_prod` |
| `ssh profiles site stag` | `site_staging` |
| `ssh profiles site` | `site_prod`, `site_staging` |
| `ssh profiles preprod` |  `site_staging` |
| `ssh profiles` | all profiles |

### Other changes

- Version bump `1.1.2.0` → `1.2.0.0`
