### PR TITLE
Move terminal selection to Flow Launcher plugin settings

### DIFF
--- a/Flow.Launcher.Plugin.easyssh/Flow.Launcher.Plugin.easyssh.csproj
+++ b/Flow.Launcher.Plugin.easyssh/Flow.Launcher.Plugin.easyssh.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net7.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
     <AssemblyName>Flow.Launcher.Plugin.easyssh</AssemblyName>
     <PackageId>Flow.Launcher.Plugin.easyssh</PackageId>
     <Authors>Melv1no</Authors>

--- a/Flow.Launcher.Plugin.easyssh/Languages/en.xaml
+++ b/Flow.Launcher.Plugin.easyssh/Languages/en.xaml
@@ -14,7 +14,7 @@
     <system:String x:Key="plugin_easyssh_databasenotcreated_subtitle">Profiles database could not be created.</system:String>
 
     <!-- Default / help -->
-    <system:String x:Key="plugin_easyssh_subtitle_default">Type: add ; remove ; profiles|p ; direct|d ; shell ; docs</system:String>
+    <system:String x:Key="plugin_easyssh_subtitle_default">Type: add ; remove ; profiles|p ; direct|d ; docs</system:String>
 
     <!-- ADD -->
     <system:String x:Key="plugin_easyssh_title_commandadd">Add profile</system:String>
@@ -32,11 +32,11 @@
     <system:String x:Key="plugin_easyssh_subtitle_commanddirectconnect">Direct connect:</system:String>
     <system:String x:Key="plugin_easyssh_title_commandshell_add">Add shell profile</system:String>
     
-    <system:String x:Key="plugin_easyssh_subtitle_commandshell_add_usage">Usage: shell add "&quot;C:\Path\MySshClient.exe&quot;" "&quot;--port {{port}} --host {{host}} --user {{user}}&quot;"</system:String>
+    <system:String x:Key="plugin_easyssh_subtitle_commandshell_add_usage">Usage: shell add "C:\Path\Terminal.exe" "-e {ssh}" (template optional, defaults to {ssh})</system:String>
 
     <system:String x:Key="plugin_easyssh_title_commandshell_remove">Remove shell profile</system:String>
     <system:String x:Key="plugin_easyssh_subtitle_commandshell_remove">Select a shell profile to remove.</system:String>
 
-    <system:String x:Key="plugin_easyssh_subtitle_commandshell_help">Use: shell add ; remove ; list</system:String>
+    <system:String x:Key="plugin_easyssh_subtitle_commandshell_help">Use: shell add ; shell remove ; or select a shell from this list.</system:String>
 
 </ResourceDictionary>

--- a/Flow.Launcher.Plugin.easyssh/Languages/fr.xaml
+++ b/Flow.Launcher.Plugin.easyssh/Languages/fr.xaml
@@ -14,7 +14,7 @@
     <system:String x:Key="plugin_easyssh_databasenotcreated_subtitle">Impossible de créer la base des profils.</system:String>
 
     <!-- Par défaut / aide -->
-    <system:String x:Key="plugin_easyssh_subtitle_default">Tapez : add ; remove ; profiles|p ; direct|d ; shell ; docs</system:String>
+    <system:String x:Key="plugin_easyssh_subtitle_default">Tapez : add ; remove ; profiles|p ; direct|d ; docs</system:String>
 
     <!-- AJOUT -->
     <system:String x:Key="plugin_easyssh_title_commandadd">Ajouter un profil</system:String>
@@ -32,11 +32,11 @@
     <system:String x:Key="plugin_easyssh_subtitle_commanddirectconnect">Connexion directe :</system:String>
 
     <system:String x:Key="plugin_easyssh_title_commandshell_add">Ajouter un profil shell</system:String>
-    <system:String x:Key="plugin_easyssh_subtitle_commandshell_add_usage">Usage : shell add "&quot;C:\Chemin\MonClientSsh.exe&quot;" "&quot;--port {{port}} --host {{host}} --user {{user}}&quot;"</system:String>
+    <system:String x:Key="plugin_easyssh_subtitle_commandshell_add_usage">Usage : shell add "C:\Chemin\Terminal.exe" "-e {ssh}" (template optionnel, défaut : {ssh})</system:String>
 
     <system:String x:Key="plugin_easyssh_title_commandshell_remove">Supprimer un profil shell</system:String>
     <system:String x:Key="plugin_easyssh_subtitle_commandshell_remove">Sélectionnez un profil shell à supprimer.</system:String>
 
-    <system:String x:Key="plugin_easyssh_subtitle_commandshell_help">Utilisez : shell add ; remove ; list</system:String>
+    <system:String x:Key="plugin_easyssh_subtitle_commandshell_help">Utilisez : shell add ; shell remove ; ou sélectionnez un shell dans la liste.</system:String>
 
 </ResourceDictionary>

--- a/Flow.Launcher.Plugin.easyssh/Main.cs
+++ b/Flow.Launcher.Plugin.easyssh/Main.cs
@@ -351,7 +351,7 @@ namespace Flow.Launcher.Plugin.EasySsh
             };
 
             panel.Children.Add(saveButton);
-            return panel;
+            return new UserControl { Content = panel };
         }
 
         public void Save()

--- a/Flow.Launcher.Plugin.easyssh/Profile.cs
+++ b/Flow.Launcher.Plugin.easyssh/Profile.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿#nullable enable
+using Newtonsoft.Json;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,7 @@ Currently, this plugin enables you to establish an SSH connection using a single
     ssh profiles (select profile to connect)
     ssh remove (select profile to delete)
     ssh add <profile name | TestProfile> <ssh args | root@127.0.0.1>
+    Terminal emulator is configured in Flow Launcher settings: Plugins > EasySSH
 
 ### To do
 


### PR DESCRIPTION
### Motivation
- Replace the in-plugin `ssh shell` interactive command with a native plugin settings panel so terminal emulator selection and argument templates are configured from Flow Launcher settings rather than search commands.
- Support emulator-specific argument templates (placeholder `{ssh}`) so different terminals (e.g. `cmd.exe`, `powershell.exe`, `kitty.exe`) can be launched with the correct argument format.

### Description
- Implement `ISettingProvider` and a `CreateSettingPanel` that exposes fields for terminal executable and argument template plus a `Save` button, persisting values into the plugin `UserData` store.
- Remove the `shell` command flow and parsing from `Query(...)` and replace it with `EnsureDefaultShellProfiles()` which seeds `cmd.exe` and `powershell.exe` defaults and a `BuildShellArguments` helper that substitutes the `{ssh}` placeholder.
- Update `RunSshCommand` to use the selected shell and formatted template when launching the process, and fallback to `cmd.exe` when no custom shell is configured.
- Enable WPF in the project file by adding `<UseWPF>true</UseWPF>`, and update English/French localization strings and `Readme.md` to reflect that terminal configuration now lives in `Flow Launcher > Plugins > EasySSH`.

### Testing
- Attempted an automated build with `dotnet build Flow.Launcher.Plugin.easyssh/Flow.Launcher.Plugin.easyssh.csproj`, but the command could not be executed in this environment because `dotnet` is not installed (build failed).
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997072ee53483279aba1bd97580db12)