### PR TITLE
feat: custom shell arguments

### DIFF
--- a/Flow.Launcher.Plugin.easyssh/Languages/en.xaml
+++ b/Flow.Launcher.Plugin.easyssh/Languages/en.xaml
@@ -32,11 +32,14 @@
     <system:String x:Key="plugin_easyssh_subtitle_commanddirectconnect">Direct connect:</system:String>
     <system:String x:Key="plugin_easyssh_title_commandshell_add">Add shell profile</system:String>
     
-    <system:String x:Key="plugin_easyssh_subtitle_commandshell_add_usage">Usage: shell add "&quot;C:\Path\MySshClient.exe&quot;" "&quot;--port {{port}} --host {{host}} --user {{user}}&quot;"</system:String>
+    <system:String x:Key="plugin_easyssh_subtitle_commandshell_add_usage_onlyexe">Usage: shell add &lt;exe&gt; or shell add &lt;name&gt; &lt;exe + args&gt;</system:String>
 
     <system:String x:Key="plugin_easyssh_title_commandshell_remove">Remove shell profile</system:String>
     <system:String x:Key="plugin_easyssh_subtitle_commandshell_remove">Select a shell profile to remove.</system:String>
 
-    <system:String x:Key="plugin_easyssh_subtitle_commandshell_help">Use: shell add ; remove ; list</system:String>
+    <system:String x:Key="plugin_easyssh_subtitle_commandshell_help_onlyexe">Use: shell add ; remove ; list</system:String>
+
+    <!-- SHELL STATUS -->
+    <system:String x:Key="plugin_easyssh_shell_selected">(selected)</system:String>
 
 </ResourceDictionary>

--- a/Flow.Launcher.Plugin.easyssh/Languages/fr.xaml
+++ b/Flow.Launcher.Plugin.easyssh/Languages/fr.xaml
@@ -32,11 +32,14 @@
     <system:String x:Key="plugin_easyssh_subtitle_commanddirectconnect">Connexion directe :</system:String>
 
     <system:String x:Key="plugin_easyssh_title_commandshell_add">Ajouter un profil shell</system:String>
-    <system:String x:Key="plugin_easyssh_subtitle_commandshell_add_usage">Usage : shell add "&quot;C:\Chemin\MonClientSsh.exe&quot;" "&quot;--port {{port}} --host {{host}} --user {{user}}&quot;"</system:String>
+    <system:String x:Key="plugin_easyssh_subtitle_commandshell_add_usage_onlyexe">Usage : shell add &lt;exe&gt; ou shell add &lt;nom&gt; &lt;exe + args&gt;</system:String>
 
     <system:String x:Key="plugin_easyssh_title_commandshell_remove">Supprimer un profil shell</system:String>
     <system:String x:Key="plugin_easyssh_subtitle_commandshell_remove">Sélectionnez un profil shell à supprimer.</system:String>
 
-    <system:String x:Key="plugin_easyssh_subtitle_commandshell_help">Utilisez : shell add ; remove ; list</system:String>
+    <system:String x:Key="plugin_easyssh_subtitle_commandshell_help_onlyexe">Utilisez : shell add ; remove ; list</system:String>
+
+    <!-- STATUT SHELL -->
+    <system:String x:Key="plugin_easyssh_shell_selected">(sélectionné)</system:String>
 
 </ResourceDictionary>

--- a/Readme.md
+++ b/Readme.md
@@ -17,6 +17,33 @@ Currently, this plugin enables you to establish an SSH connection using a single
     ssh remove (select profile to delete)
     ssh add <profile name | TestProfile> <ssh args | root@127.0.0.1>
 
+### Custom Shell
+
+By default, SSH connections are opened with `cmd.exe`. You can configure a custom shell:
+
+    ssh shell add <exe>
+
+Example:
+
+    ssh shell add wt.exe
+
+You can also define a named shell with custom arguments. This is useful when the executable needs extra parameters (e.g. selecting a Windows Terminal profile):
+
+    ssh shell add <name> <exe + args>
+
+Example:
+
+    ssh shell add wt-gitbash wt.exe -p "Git Bash"
+
+When a profile SSH command runs, the plugin will execute:
+
+    wt.exe -p "Git Bash" ssh user@host
+
+Other shell commands:
+
+    ssh shell              (list configured shells)
+    ssh shell remove       (select a shell to delete)
+
 ### To do
 
     ssh scp d <file> <user@host>:<destination>


### PR DESCRIPTION
## Custom shell with arguments

`CustomShellLists` now supports an optional value containing the executable and its arguments. If the value is empty, the key is used as the executable (existing behavior). If the value is set, the key acts as an identifier and the value holds the exe + args.

Example with Windows Terminal:
```
ssh shell add git-bash wt.exe -p "Git Bash"
```

Example `profiles.json` config:
```json
{
  "CustomShellLists": {
    "wt.exe": "",
    "git-bash": "wt.exe -p \"Git Bash\""
  },
  "SelectedCustomShell": "git-bash"
}
```

The `shell add` command retains quoted path parsing for paths with spaces (fully backward compatible).

No breaking changes on JSON data or commands.

## Translations

- Added missing keys `plugin_easyssh_subtitle_commandshell_add_usage_onlyexe` and `plugin_easyssh_subtitle_commandshell_help_onlyexe` (EN + FR)
- Replaced hardcoded `"(selected)"` strings with `plugin_easyssh_shell_selected` translation key (EN + FR)
- Removed unused legacy keys

## Other

- Updated Readme documentation (custom shell, profile search)
