### PR TITLE
fix: resolve shell executable full path before launching process

### DIFF
--- a/Flow.Launcher.Plugin.easyssh/Main.cs
+++ b/Flow.Launcher.Plugin.easyssh/Main.cs
@@ -565,7 +565,7 @@ namespace Flow.Launcher.Plugin.EasySsh
 
                 var psiShell = new ProcessStartInfo
                 {
-                    FileName = fileName,
+                    FileName = Utils.ResolveExecutable(fileName),
                     Arguments = arguments,
                     RedirectStandardInput = false,
                     RedirectStandardOutput = false,
@@ -580,7 +580,7 @@ namespace Flow.Launcher.Plugin.EasySsh
             // Sinon fallback : cmd.exe <originalSshCmd>
             var psi = new ProcessStartInfo
             {
-                FileName = _sshClient,
+                FileName = Utils.ResolveExecutable(_sshClient),
                 Arguments = originalSshCmd,
                 RedirectStandardInput = false,
                 RedirectStandardOutput = false,

--- a/Flow.Launcher.Plugin.easyssh/Utils.cs
+++ b/Flow.Launcher.Plugin.easyssh/Utils.cs
@@ -14,6 +14,41 @@ namespace Flow.Launcher.Plugin.easyssh
         /// Checks if SSH is installed on the system.
         /// </summary>
         /// <returns><c>true</c> if SSH is installed; otherwise, <c>false</c>.</returns>
+        /// <summary>
+        /// Resolves the full path of an executable using the 'where' command.
+        /// Returns the original name if resolution fails (let the OS handle it).
+        /// </summary>
+        public static string ResolveExecutable(string exeName)
+        {
+            // Already an absolute path — no need to resolve
+            if (Path.IsPathRooted(exeName) && File.Exists(exeName))
+                return exeName;
+
+            try
+            {
+                var p = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = "where",
+                        Arguments = exeName,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    }
+                };
+                p.Start();
+                string output = p.StandardOutput.ReadLine(); // first result is enough
+                p.WaitForExit();
+                if (!string.IsNullOrWhiteSpace(output) && File.Exists(output.Trim()))
+                    return output.Trim();
+            }
+            catch { /* fall through */ }
+
+            return exeName;
+        }
+
         public static bool IsSshInstalled()
         {
             // Create a new process to run the 'where' command to locate the 'ssh' executable.

--- a/Flow.Launcher.Plugin.easyssh/plugin.json
+++ b/Flow.Launcher.Plugin.easyssh/plugin.json
@@ -4,7 +4,7 @@
     "Name": "EasySSH",
     "Description": "ssh with Flow-Launcher",
     "Author": "Melv1no",
-    "Version": "1.2.0.1",
+    "Version": "1.2.0.2",
     "Language": "csharp",
     "Website": "https://github.com/Melv1no/Flow.Launcher.Plugin.easyssh",
     "IcoPath": "Images\\app.png",


### PR DESCRIPTION
When launching a terminal process with `UseShellExecute = true`, Windows resolves the executable relative to the working directory of Flow Launcher, not the system PATH. 
This causes any shell executable (e.g. `wt.exe`) to fail with a Win32Exception if it's not in that directory.

This fix adds a `ResolveExecutable` helper in `Utils` that uses `where` to resolve the full path of the executable before launching, falling back to the original name if resolution fails.