### PR TITLE
fix: pass /c flag to cmd.exe for direct connect

### DIFF
--- a/Flow.Launcher.Plugin.easyssh/Main.cs
+++ b/Flow.Launcher.Plugin.easyssh/Main.cs
@@ -577,11 +577,11 @@ namespace Flow.Launcher.Plugin.EasySsh
                 return;
             }
 
-            // Sinon fallback : cmd.exe <originalSshCmd>
+            // Sinon fallback : cmd.exe /c <originalSshCmd>
             var psi = new ProcessStartInfo
             {
                 FileName = Utils.ResolveExecutable(_sshClient),
-                Arguments = originalSshCmd,
+                Arguments = $"/c {originalSshCmd}",
                 RedirectStandardInput = false,
                 RedirectStandardOutput = false,
                 RedirectStandardError = false,


### PR DESCRIPTION
## Summary

When using the `d` (direct connect) command, the plugin opens a terminal but does not connect to the remote server.

## Root cause

The fallback path in `RunSshCommand` launches `cmd.exe` with the SSH command as a bare argument without the `/c` switch. This causes `cmd.exe` to simply open an interactive prompt and ignore positional arguments entirely.

## Fix

Add the `/c` flag so `cmd.exe` actually executes the SSH command. The terminal stays open while the SSH session is active (SSH is interactive) and closes when the session ends.

Fixes #9
